### PR TITLE
Fix region variable mismatches

### DIFF
--- a/.env.init
+++ b/.env.init
@@ -1,3 +1,3 @@
 AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
-AWS_DEFAULT_REGION=us-east-1
+AWS_REGION=eu-central-1

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -22,7 +22,7 @@ usage() {
     echo ""
     echo "Available environments: dev, staging, prod"
     echo "Default environment: dev"
-    echo "Default region: us-east-1"
+    echo "Default region: eu-central-1"
     exit 1
 }
 

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -31,7 +31,7 @@ To deploy the Lambda function, run the following command in the `infrastructure`
 ```
 
 - `environment`: The deployment environment (e.g., `dev`, `staging`, `prod`). Default is `dev`.
-- `region`: The AWS region to deploy to. Default is `us-east-1`.
+- `region`: The AWS region to deploy to. Default is `eu-central-1`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- fix .env example to use AWS_REGION and eu-central-1
- update deploy script usage message
- correct default region documentation

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68427f1187888332bd60ff5f2e599219