### PR TITLE
Fix Zig missing error in CI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,6 +36,13 @@ jobs:
             cargo install cargo-lambda
           fi
 
+      - name: Install Zig
+        run: |
+          if ! command -v zig &> /dev/null; then
+            python3 -m pip install --user ziglang
+            echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- ensure Zig is installed before running deploy script
- fix indentation in workflow YAML

## Testing
- `make test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d3b836de08332a451cd6123ba5864