### PR TITLE
Fix Zig missing error in CI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,6 +36,11 @@ jobs:
             cargo install cargo-lambda
           fi
 
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- ensure Zig is installed using setup-zig action
- fix indentation in workflow YAML

## Testing
- `make test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d3b836de08332a451cd6123ba5864